### PR TITLE
Dismiss the sideMenu programmatically.

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -255,14 +255,9 @@ open class SideMenuManager: NSObject {
         }
     }
 
-    /// This dismisses the currently presented view controller and hide the sideMenu.
+    /// This dismisses the currently presented view controller and hides the sideMenu.
     public func hideMenu() {
-        if let menuViewController: UINavigationController = sideMenuTransition.presentDirection == .left ? menuLeftNavigationController : menuRightNavigationController,
-            menuViewController.presentedViewController == nil {
-            sideMenuTransition.hideMenuStart()
-            sideMenuTransition.hideMenuComplete()
-            menuViewController.dismiss(animated: false, completion: nil)
-        }
+        sideMenuTransition.hideMenu()
     }
 
     /**

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -255,6 +255,13 @@ open class SideMenuManager: NSObject {
         }
     }
 
+    public func hideMenu() {
+        if menuRightNavigationController != nil || menuLeftNavigationController != nil {
+            sideMenuTransition.hideMenuStart()
+            sideMenuTransition.hideMenuComplete()
+        }
+    }
+
     /**
      Adds screen edge gestures to a view to present a menu.
      

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -255,10 +255,13 @@ open class SideMenuManager: NSObject {
         }
     }
 
+    /// This dismisses the currently presented view controller and hide the sideMenu.
     public func hideMenu() {
-        if menuRightNavigationController != nil || menuLeftNavigationController != nil {
+        if let menuViewController: UINavigationController = sideMenuTransition.presentDirection == .left ? menuLeftNavigationController : menuRightNavigationController,
+            menuViewController.presentedViewController == nil {
             sideMenuTransition.hideMenuStart()
             sideMenuTransition.hideMenuComplete()
+            menuViewController.dismiss(animated: false, completion: nil)
         }
     }
 

--- a/Pod/Classes/SideMenuTransition.swift
+++ b/Pod/Classes/SideMenuTransition.swift
@@ -472,6 +472,10 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition, UIViewContr
     }
 
     internal func applicationDidEnterBackgroundNotification() {
+        hideMenu()
+    }
+
+    internal func hideMenu() {
         guard let sideMenuManager = sideMenuManager else {
             return
         }


### PR DESCRIPTION
This method is needed for the deep linking programmatic dismissal of view controllers so that the `SideMenu` slides out of the way.

Otherwise, it looks like this. The article on the left is the deep linked asset but the side menu is still in view:
![screen shot 2017-04-19 at 5 00 03 pm](https://cloud.githubusercontent.com/assets/221078/25203818/b395b9ee-2528-11e7-863b-e0f67c7c772a.png)
